### PR TITLE
Add Github Action for building Docker images with R version extraction for tags

### DIFF
--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -47,7 +47,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push container image to ghcr
@@ -132,7 +132,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata for container image
@@ -147,10 +147,9 @@ jobs:
         id: vars
         run: |
           echo container=$(echo '${{ steps.meta.outputs.tags }}' | awk -F':' '{print $1}') >> $GITHUB_OUTPUT
-          echo containerbase=$(echo '${{ steps.meta.outputs.tags }}' | awk -F':' '{print $1}' | awk 'BEGIN{FS=OFS="/"}{NF--; print}') >> $GITHUB_OUTPUT
 
       - name: Create manifest list and push
         run: |
           cd /tmp/digests
           ls --hide=digestdirs > digestdirs
-          cat digestdirs | xargs -i bash -c 'docker buildx imagetools create ${{steps.vars.outputs.containerbase}}/{} $(printf "${{ steps.vars.outputs.container }}@sha256:%s " {}/*)'
+          cat digestdirs | xargs -i bash -c 'docker buildx imagetools create -t ${{steps.vars.outputs.container}}:{} $(for f in {}/*; do basename "$f"; done | xargs printf "${{steps.vars.outputs.container}}@sha256:%s ")'

--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -1,0 +1,55 @@
+name: Build Container Images
+on:
+  push:
+    paths:
+      - "**/Dockerfile"
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  ghcrbuild:
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu: [focal, jammy]
+
+    name: Build container images for GHCR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Extract metadata for container image
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ matrix.ubuntu }}
+
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: linux/amd64, linux/arm64
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push container image to ghcr
+        uses: docker/build-push-action@v4
+        with:
+          file: ${{matrix.ubuntu}}/Dockerfile
+          push: true
+          load: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64, linux/arm64
+

--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu: [focal, jammy]
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64]
 
     name: Build container images for GHCR
     runs-on: ubuntu-latest

--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -6,6 +6,9 @@ on:
       - "**/Dockerfile"
   schedule:
     - cron: '0 0 */2 * *'
+# Avoids Github UI bugs https://github.com/orgs/community/discussions/45969
+env:
+  BUILDX_NO_DEFAULT_ATTESTATIONS: 1
 jobs:
   ghcrbuild:
     strategy:
@@ -58,6 +61,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ steps.vars.outputs.container }},push-by-digest=true,name-canonical=true,push=true
           platforms: ${{matrix.platform}}
+          provenance: false
 
       - name: Prepare Dockerfile to extract R version with emulator
         run: |
@@ -76,6 +80,7 @@ jobs:
           context: .
           push: false
           load: false
+          provenance: false
           outputs: type=tar,dest=${{matrix.ubuntu}}-${{matrix.platform}}/r.tar
           tags: ${{ steps.meta.outputs.tags }}-r
           platforms: ${{ matrix.platform }}
@@ -107,7 +112,6 @@ jobs:
           path: /tmp/digests/**
           if-no-files-found: error
           retention-days: 1
-
 
   merge:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -49,7 +49,6 @@ jobs:
         with:
           file: ${{matrix.ubuntu}}/Dockerfile
           push: true
-          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64, linux/arm64

--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -5,13 +5,14 @@ on:
     paths:
       - "**/Dockerfile"
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 */2 * *'
 jobs:
   ghcrbuild:
     strategy:
       fail-fast: false
       matrix:
         ubuntu: [focal, jammy]
+        platform: [linux/amd64, linux/arm64]
 
     name: Build container images for GHCR
     runs-on: ubuntu-latest
@@ -26,16 +27,21 @@ jobs:
           tags: |
             type=raw,value=${{ matrix.ubuntu }}
 
+      - name: Extract container name without tag
+        id: vars
+        run: |
+          echo container=$(echo '${{ steps.meta.outputs.tags }}' | awk -F':' '{print $1}') >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
         with:
           platforms: arm64
+        if: contains(steps.versions.outputs.platform, 'arm64')
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          platforms: linux/amd64, linux/arm64
+          platforms: ${{matrix.platform}}
 
       - name: Login to GHCR
         uses: docker/login-action@v2
@@ -45,11 +51,106 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push container image to ghcr
+        id: build
         uses: docker/build-push-action@v4
         with:
           file: ${{matrix.ubuntu}}/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64, linux/arm64
+          outputs: type=image,name=${{ steps.vars.outputs.container }},push-by-digest=true,name-canonical=true,push=true
+          platforms: ${{matrix.platform}}
 
+      - name: Export digest by ubuntu
+        run: |
+          digest="${{ steps.build.outputs.digest }}"
+          mkdir -p /tmp/digests/${{matrix.ubuntu}}
+          touch "/tmp/digests/${{matrix.ubuntu}}/${digest#sha256:}"
+
+      - name: Prepare Dockerfile to extract R version with emulator
+        run: |
+          mkdir -p ${{matrix.ubuntu}}-${{matrix.platform}}
+          cat << "EOF" > ${{matrix.ubuntu}}-${{matrix.platform}}-r.Dockerfile
+          FROM ${{ steps.vars.outputs.container }}@${{ steps.build.outputs.digest }} as extract
+          RUN mkdir /r2utmp && R --version > /r2utmp/rver
+          FROM scratch as export
+          COPY --from=extract /r2utmp/rver /
+          EOF
+
+      - name: Build and push container image to ghcr
+        uses: docker/build-push-action@v4
+        with:
+          file: ${{matrix.ubuntu}}-${{matrix.platform}}-r.Dockerfile
+          context: .
+          push: false
+          load: false
+          outputs: type=tar,dest=${{matrix.ubuntu}}-${{matrix.platform}}/r.tar
+          tags: ${{ steps.meta.outputs.tags }}-r
+          platforms: ${{ matrix.platform }}
+
+      - name: Extract rversion
+        id: rver
+        run: |
+          cd ${{matrix.ubuntu}}-${{matrix.platform}}
+          tar -xvf r.tar
+          echo version=$(cat rver | awk 'NR==1{print $3}') >> $GITHUB_OUTPUT
+
+      - name: Export digest by ubuntu and r version
+        run: |
+          digest="${{ steps.build.outputs.digest }}"
+          mkdir -p /tmp/digests/${{matrix.ubuntu}}-r-${{steps.rver.outputs.version}}
+          touch "/tmp/digests/${{matrix.ubuntu}}-r-${{steps.rver.outputs.version}}/${digest#sha256:}"
+
+      - name: Upload digests
+        uses: actions/upload-artifact@v3
+        with:
+          name: r2udigests
+          path: /tmp/digests/**
+          if-no-files-found: error
+          retention-days: 1
+
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - ghcrbuild
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu: [focal, jammy]
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: r2udigests
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          platforms: ${{matrix.platform}}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for container image
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ matrix.ubuntu }}
+
+      - name: Extract container name without tag
+        id: vars
+        run: |
+          echo container=$(echo '${{ steps.meta.outputs.tags }}' | awk -F':' '{print $1}') >> $GITHUB_OUTPUT
+          echo containerbase=$(echo '${{ steps.meta.outputs.tags }}' | awk -F':' '{print $1}' | awk 'BEGIN{FS=OFS="/"}{NF--; print}') >> $GITHUB_OUTPUT
+
+      - name: Create manifest list and push
+        run: |
+          cd /tmp/digests
+          ls --hide=digestdirs > digestdirs
+          cat digestdirs | xargs -i bash -c 'docker buildx imagetools create ${{steps.vars.outputs.containerbase}}/{} $(printf "${{ steps.vars.outputs.container }}@sha256:%s " {}/*)'

--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Upload digests
         uses: actions/upload-artifact@v3
         with:
-          name: r2udigests
+          name: r2udigests-${{ github.run_id }}
           path: /tmp/digests/**
           if-no-files-found: error
           retention-days: 1
@@ -122,7 +122,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v3
         with:
-          name: r2udigests
+          name: r2udigests-${{ github.run_id }}
           path: /tmp/digests
 
       - name: Set up Docker Buildx

--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -59,20 +59,14 @@ jobs:
           outputs: type=image,name=${{ steps.vars.outputs.container }},push-by-digest=true,name-canonical=true,push=true
           platforms: ${{matrix.platform}}
 
-      - name: Export digest by ubuntu
-        run: |
-          digest="${{ steps.build.outputs.digest }}"
-          mkdir -p /tmp/digests/${{matrix.ubuntu}}
-          touch "/tmp/digests/${{matrix.ubuntu}}/${digest#sha256:}"
-
       - name: Prepare Dockerfile to extract R version with emulator
         run: |
           mkdir -p ${{matrix.ubuntu}}-${{matrix.platform}}
           cat << "EOF" > ${{matrix.ubuntu}}-${{matrix.platform}}-r.Dockerfile
           FROM ${{ steps.vars.outputs.container }}@${{ steps.build.outputs.digest }} as extract
-          RUN mkdir /r2utmp && R --version > /r2utmp/rver
+          RUN mkdir /r2utmp && R --version > /r2utmp/rver && cat /etc/os-release > /r2utmp/os-release
           FROM scratch as export
-          COPY --from=extract /r2utmp/rver /
+          COPY --from=extract /r2utmp/* /
           EOF
 
       - name: Build and push container image to ghcr
@@ -87,17 +81,24 @@ jobs:
           platforms: ${{ matrix.platform }}
 
       - name: Extract rversion
-        id: rver
+        id: versions
         run: |
           cd ${{matrix.ubuntu}}-${{matrix.platform}}
           tar -xvf r.tar
-          echo version=$(cat rver | awk 'NR==1{print $3}') >> $GITHUB_OUTPUT
+          echo rver=$(cat rver | awk 'NR==1{print $3}') >> $GITHUB_OUTPUT
+          echo osver=$(awk -F= '/VERSION_ID/ {gsub("\"", "", $2); print $2}' os-release) >> $GITHUB_OUTPUT
 
-      - name: Export digest by ubuntu and r version
+      - name: Export digest by ubuntu and r versions
         run: |
           digest="${{ steps.build.outputs.digest }}"
-          mkdir -p /tmp/digests/${{matrix.ubuntu}}-r-${{steps.rver.outputs.version}}
-          touch "/tmp/digests/${{matrix.ubuntu}}-r-${{steps.rver.outputs.version}}/${digest#sha256:}"
+          mkdir -p /tmp/digests/${{matrix.ubuntu}}
+          touch "/tmp/digests/${{matrix.ubuntu}}/${digest#sha256:}"
+          mkdir -p /tmp/digests/${{matrix.ubuntu}}-r-${{steps.versions.outputs.rver}}
+          touch "/tmp/digests/${{matrix.ubuntu}}-r-${{steps.versions.outputs.rver}}/${digest#sha256:}"
+          mkdir -p /tmp/digests/${{steps.versions.outputs.osver}}
+          touch "/tmp/digests/${{steps.versions.outputs.osver}}/${digest#sha256:}"
+          mkdir -p /tmp/digests/${{steps.versions.outputs.osver}}-r-${{steps.versions.outputs.rver}}
+          touch "/tmp/digests/${{steps.versions.outputs.osver}}-r-${{steps.versions.outputs.rver}}/${digest#sha256:}"
 
       - name: Upload digests
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -1,5 +1,6 @@
 name: Build Container Images
 on:
+  workflow_dispatch:
   push:
     paths:
       - "**/Dockerfile"

--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu: [focal, jammy]
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64]
 
     name: Build container images for GHCR
     runs-on: ubuntu-latest

--- a/.github/workflows/build_ghcr.yaml
+++ b/.github/workflows/build_ghcr.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         ubuntu: [focal, jammy]
-        platform: [linux/amd64]
+        platform: [linux/amd64, linux/arm64]
 
     name: Build container images for GHCR
     runs-on: ubuntu-latest
@@ -112,6 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - ghcrbuild
+    if: always()
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
I started this as a way to keep different R version containers for Bioconductor use since we need containers per R version, but I figured it might be a useful contribution upstream

This will rebuild the r2u Docker images every 2 days or any commit to a Dockerfile, and push with tags `[ubuntu name]` `[ubuntu name]-r-[rversion]` `[ubuntu version]` `[ubuntu version]-r-[rversion]` (see example in screenshot) 
<img width="459" alt="image" src="https://github.com/rocker-org/r2u/assets/14061824/142bf017-0f0f-43ba-adb4-123a5c9fae0a">

without pinning the version in the script, by extracting the versions after the fact to push each image with tags based on both ubuntu and r version.
While arm64 builds are currently failing (I think due to R version mismatches), this design allows each image be built separately and pushed by digest first, then merged into tags allowing for various platforms to be pushed under the same tag once available.

I am also happy to add Dockerhub target to this so they get built together, if you tell me what secrets to expect credentials under.

Can also keep this as a Bioconductor internal thing if you're not interested.