### PR TITLE
Add adduser command

### DIFF
--- a/noble/Dockerfile
+++ b/noble/Dockerfile
@@ -18,6 +18,7 @@ RUN useradd -s /bin/bash -m docker \
 		ca-certificates \
 		locales \
 		wget \
+		adduser \
 ## Install key and setup R repo at CRAN
         && wget -q -O - https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc \
                 | tee -a /etc/apt/trusted.gpg.d/cran_ubuntu_key.asc  \


### PR DESCRIPTION
Hi Dirk,

I was trying to add user and user group to an image. It works file with versions 22.04 and older.

However, when I try the 24.04 version, I can't find these commands:

```Dockerfile
FROM rocker/r2u:22.04
RUN addgroup --system app && adduser --system --ingroup app app

# build fails:
#  > [2/2] RUN addgroup --system app && adduser --system --ingroup app app:
# 0.171 /bin/sh: 1: addgroup: not found
```

Same thing happens with the `ubuntu:noble`.

It would be nice to have `adduser` available without the extra hoop, this PR does that by installing `adduser`. 

Thanks!
